### PR TITLE
Add session id generator

### DIFF
--- a/common.go
+++ b/common.go
@@ -846,6 +846,8 @@ type Config struct {
 	// used for debugging.
 	KeyLogWriter io.Writer
 
+	SessionIDGenerator func(clientHello []byte, sessionID []byte) error
+
 	// EncryptedClientHelloConfigList is a serialized ECHConfigList. If
 	// provided, clients will attempt to connect to servers using Encrypted
 	// Client Hello (ECH) using one of the provided ECHConfigs. Servers
@@ -984,6 +986,7 @@ func (c *Config) Clone() *Config {
 		DynamicRecordSizingDisabled:         c.DynamicRecordSizingDisabled,
 		Renegotiation:                       c.Renegotiation,
 		KeyLogWriter:                        c.KeyLogWriter,
+		SessionIDGenerator:          c.SessionIDGenerator,
 		EncryptedClientHelloConfigList:      c.EncryptedClientHelloConfigList,
 		EncryptedClientHelloRejectionVerify: c.EncryptedClientHelloRejectionVerify,
 		sessionTicketKeys:                   c.sessionTicketKeys,

--- a/u_conn.go
+++ b/u_conn.go
@@ -554,6 +554,23 @@ func (c *UConn) clientHandshake(ctx context.Context) (err error) {
 		}()
 	}
 
+	// A random session ID is used to detect when the server accepted a ticket
+	// and is resuming a session (see RFC 5077). In TLS 1.3, it's always set as
+	// a compatibility measure (see RFC 8446, Section 4.1.2).
+	if c.config.SessionIDGenerator != nil {
+		hello.sessionId = make([]byte, 32)
+		hello.raw = nil
+		data, err := hello.marshal()
+		if err != nil {
+			return err
+		}
+		err = c.config.SessionIDGenerator(data, hello.sessionId)
+		if err != nil {
+			return errors.New("tls: generate session id failed: " + err.Error())
+		}
+		hello.raw = nil
+	}
+
 	if _, err := c.writeHandshakeRecord(hello, nil); err != nil {
 		return err
 	}


### PR DESCRIPTION
A random session ID is used to detect when the server accepted a ticket and is resuming a session (see RFC 5077). In TLS 1.3, it's always set as a compatibility measure (see RFC 8446, Section 4.1.2).